### PR TITLE
Use rust lib to set target vendor

### DIFF
--- a/crate2nix/Cargo.nix
+++ b/crate2nix/Cargo.nix
@@ -2367,12 +2367,12 @@ rec {
     os = pkgs.rust.lib.toTargetOs platform;
     arch = pkgs.rust.lib.toTargetArch platform;
     family = pkgs.rust.lib.toTargetFamily platform;
+    vendor = pkgs.rust.lib.toTargetVendor platform;
     env = "gnu";
     endian =
       if platform.parsed.cpu.significantByte.name == "littleEndian"
       then "little" else "big";
     pointer_width = toString platform.parsed.cpu.bits;
-    vendor = platform.parsed.vendor.name;
     debug_assertions = false;
   };
 

--- a/crate2nix/templates/nix/crate2nix/default.nix
+++ b/crate2nix/templates/nix/crate2nix/default.nix
@@ -34,12 +34,12 @@ rec {
     os = pkgs.rust.lib.toTargetOs platform;
     arch = pkgs.rust.lib.toTargetArch platform;
     family = pkgs.rust.lib.toTargetFamily platform;
+    vendor = pkgs.rust.lib.toTargetVendor platform;
     env = "gnu";
     endian =
       if platform.parsed.cpu.significantByte.name == "littleEndian"
       then "little" else "big";
     pointer_width = toString platform.parsed.cpu.bits;
-    vendor = platform.parsed.vendor.name;
     debug_assertions = false;
   };
 

--- a/sample_projects/bin_with_git_branch_dep/Cargo.nix
+++ b/sample_projects/bin_with_git_branch_dep/Cargo.nix
@@ -147,12 +147,12 @@ rec {
     os = pkgs.rust.lib.toTargetOs platform;
     arch = pkgs.rust.lib.toTargetArch platform;
     family = pkgs.rust.lib.toTargetFamily platform;
+    vendor = pkgs.rust.lib.toTargetVendor platform;
     env = "gnu";
     endian =
       if platform.parsed.cpu.significantByte.name == "littleEndian"
       then "little" else "big";
     pointer_width = toString platform.parsed.cpu.bits;
-    vendor = platform.parsed.vendor.name;
     debug_assertions = false;
   };
 

--- a/sample_projects/bin_with_git_submodule_dep/Cargo.nix
+++ b/sample_projects/bin_with_git_submodule_dep/Cargo.nix
@@ -1382,12 +1382,12 @@ rec {
     os = pkgs.rust.lib.toTargetOs platform;
     arch = pkgs.rust.lib.toTargetArch platform;
     family = pkgs.rust.lib.toTargetFamily platform;
+    vendor = pkgs.rust.lib.toTargetVendor platform;
     env = "gnu";
     endian =
       if platform.parsed.cpu.significantByte.name == "littleEndian"
       then "little" else "big";
     pointer_width = toString platform.parsed.cpu.bits;
-    vendor = platform.parsed.vendor.name;
     debug_assertions = false;
   };
 

--- a/sample_projects/codegen/Cargo.nix
+++ b/sample_projects/codegen/Cargo.nix
@@ -514,12 +514,12 @@ rec {
     os = pkgs.rust.lib.toTargetOs platform;
     arch = pkgs.rust.lib.toTargetArch platform;
     family = pkgs.rust.lib.toTargetFamily platform;
+    vendor = pkgs.rust.lib.toTargetVendor platform;
     env = "gnu";
     endian =
       if platform.parsed.cpu.significantByte.name == "littleEndian"
       then "little" else "big";
     pointer_width = toString platform.parsed.cpu.bits;
-    vendor = platform.parsed.vendor.name;
     debug_assertions = false;
   };
 

--- a/sample_projects/sub_dir_crates/Cargo.nix
+++ b/sample_projects/sub_dir_crates/Cargo.nix
@@ -166,12 +166,12 @@ rec {
     os = pkgs.rust.lib.toTargetOs platform;
     arch = pkgs.rust.lib.toTargetArch platform;
     family = pkgs.rust.lib.toTargetFamily platform;
+    vendor = pkgs.rust.lib.toTargetVendor platform;
     env = "gnu";
     endian =
       if platform.parsed.cpu.significantByte.name == "littleEndian"
       then "little" else "big";
     pointer_width = toString platform.parsed.cpu.bits;
-    vendor = platform.parsed.vendor.name;
     debug_assertions = false;
   };
 


### PR DESCRIPTION
Uses the new rust lib function `toTargetVendor` for setting the vendor for feature/dependency resolution & regenerated `Cargo.nix` files. Needs nixpkgs to be updated to a version of 21.11 that includes `toTargetVendor`, unsure how to do that.