### PR TITLE
allow git deps to have workspaces

### DIFF
--- a/tools.nix
+++ b/tools.nix
@@ -380,11 +380,28 @@ rec {
                 inherit sha256;
                 inherit (parsed) url rev;
               };
+
+              rootCargo = builtins.fromTOML (builtins.readFile "${src}/Cargo.toml");
+              isWorkspace = rootCargo ? "workspace";
+              isPackage = rootCargo ? "package";
+              containedCrates = rootCargo.workspace.members ++ (if isPackage then ["."] else []);
+
+              getCrateNameFromPath = path: let
+                cargoTomlCrate = builtins.fromTOML (builtins.readFile "${src}/${path}/Cargo.toml");
+              in
+                cargoTomlCrate.package.name;
+
+              pathToExtract = if isWorkspace then
+                builtins.head (builtins.filter (to_filter:
+                  (getCrateNameFromPath to_filter) == name
+                ) containedCrates)
+              else
+               ".";
             in
             pkgs.runCommand (lib.removeSuffix ".tar.gz" src.name) { }
               ''
                 mkdir -p $out
-                cp -apR ${src}/* $out
+                cp -apR ${src}/${pathToExtract}/* $out
                 echo '{"package":null,"files":{}}' > $out/.cargo-checksum.json
               '';
 


### PR DESCRIPTION
This should be correctly credited to @marius851000 since I copied it directly from https://github.com/kolloch/crate2nix/pull/166/, since it was a narrow part of that changeset that I could understand/justify.

What it does is, in the case that you have a git reference to a crate whose git repo contains workspaces, e.g. [mutagen](https://github.com/llogiq/mutagen/blob/master/Cargo.toml), then rather than trying to directly use the root Cargo.toml (which has no information, just a list of workspaces), it parses it to find the path to the *actual* Cargo.toml for the crate we're trying to depend on, and uses that.