### PR TITLE
Set meta.mainProgram in default.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -61,6 +61,7 @@ pkgs.symlinkJoin {
       }
       lib.maintainers.andir
     ];
+    mainProgram = crate2nix.name;
     platforms = lib.platforms.all;
   };
   postBuild = ''


### PR DESCRIPTION
This ensures you can use `nix run` directly with the package