### PR TITLE
Fix meta.mainProgram

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -61,7 +61,7 @@ pkgs.symlinkJoin {
       }
       lib.maintainers.andir
     ];
-    mainProgram = crate2nix.name;
+    mainProgram = "crate2nix";
     platforms = lib.platforms.all;
   };
   postBuild = ''


### PR DESCRIPTION
I mindlessly copied the existing `.name` reference but that actually returns something like `rust_crate2nix-0.11.0-rc.4` 🤦‍♂️ 

This should work