### PR TITLE
Add flake.nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,44 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,19 @@
+{
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, flake-utils }: {
+    overlays.default = self: super: {
+      crate2nix = self.callPackage ./default.nix { };
+    };
+  } // flake-utils.lib.eachDefaultSystem (system: let
+    sources = import ./nix/sources.nix;
+    pkgs = import sources.nixpkgs { inherit system; };
+  in {
+    packages = rec {
+      crate2nix = pkgs.callPackage ./default.nix { };
+      default = crate2nix;
+    };
+  });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -7,13 +7,16 @@
     overlays.default = self: super: {
       crate2nix = self.callPackage ./default.nix { };
     };
-  } // flake-utils.lib.eachDefaultSystem (system: let
-    sources = import ./nix/sources.nix;
-    pkgs = import sources.nixpkgs { inherit system; };
-  in {
-    packages = rec {
-      crate2nix = pkgs.callPackage ./default.nix { };
-      default = crate2nix;
-    };
-  });
+  } // flake-utils.lib.eachDefaultSystem (system:
+    let
+      sources = import ./nix/sources.nix;
+      pkgs = import sources.nixpkgs { inherit system; };
+    in
+    {
+      formatter = pkgs.nixpkgs-fmt;
+      packages = rec {
+        crate2nix = pkgs.callPackage ./default.nix { };
+        default = crate2nix;
+      };
+    });
 }


### PR DESCRIPTION
This adds a flake.nix with an overlay and a package. The nixpkgs is pinned to the one used by the rest of the repository, so its nixpkgs version is not managed separately.

After this PR `crate2nix` can be run by calling `nix run github:nix-community/crate2nix`. Crate2nix can also be used via the overlay by using `crate2nix.overlays.default`