### PR TITLE
Use macos-latest in CI

### DIFF
--- a/.github/workflows/tests-nix-macos.yml
+++ b/.github/workflows/tests-nix-macos.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         platform:
-          - macos-10.15
+          - macos-latest
     runs-on: ${{ matrix.platform }}
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
macos-10 is deprecated, which is why it doesn't get scheduled