### PR TITLE
Run tests in debug mode

### DIFF
--- a/crate2nix/Cargo.nix
+++ b/crate2nix/Cargo.nix
@@ -2444,6 +2444,7 @@ rec {
             (
               _: {
                 buildTests = true;
+                release = false;
               }
             );
           # If the user hasn't set any pre/post commands, we don't want to

--- a/crate2nix/templates/nix/crate2nix/default.nix
+++ b/crate2nix/templates/nix/crate2nix/default.nix
@@ -111,6 +111,7 @@ rec {
             (
               _: {
                 buildTests = true;
+                release = false;
               }
             );
           # If the user hasn't set any pre/post commands, we don't want to

--- a/sample_projects/bin_with_git_submodule_dep/Cargo.nix
+++ b/sample_projects/bin_with_git_submodule_dep/Cargo.nix
@@ -1459,6 +1459,7 @@ rec {
             (
               _: {
                 buildTests = true;
+                release = false;
               }
             );
           # If the user hasn't set any pre/post commands, we don't want to

--- a/sample_projects/codegen/Cargo.nix
+++ b/sample_projects/codegen/Cargo.nix
@@ -591,6 +591,7 @@ rec {
             (
               _: {
                 buildTests = true;
+                release = false;
               }
             );
           # If the user hasn't set any pre/post commands, we don't want to

--- a/sample_projects/sub_dir_crates/Cargo.nix
+++ b/sample_projects/sub_dir_crates/Cargo.nix
@@ -243,6 +243,7 @@ rec {
             (
               _: {
                 buildTests = true;
+                release = false;
               }
             );
           # If the user hasn't set any pre/post commands, we don't want to


### PR DESCRIPTION
Previously, crate2nix tests were run equivalently to `cargo test --release`, which is a somewhat unusual default configuration.

It might be worth having a flag to tweak this behaviour, similar to Cargo. A more ambitious version yet would permit running both debug and release versions of the tests. I'm not sure what the best interface for either of those is.