### PR TITLE
fix: resolve missing target features to 'null'

### DIFF
--- a/crate2nix/Cargo.nix
+++ b/crate2nix/Cargo.nix
@@ -122,7 +122,7 @@ rec {
           {
             name = "winapi";
             packageId = "winapi";
-            target = { target, features }: ("windows" == target."os");
+            target = { target, features }: ("windows" == target."os" or null);
             features = [ "consoleapi" "errhandlingapi" "fileapi" "handleapi" "processenv" ];
           }
         ];
@@ -157,7 +157,7 @@ rec {
           {
             name = "hermit-abi";
             packageId = "hermit-abi";
-            target = { target, features }: ("hermit" == target."os");
+            target = { target, features }: ("hermit" == target."os" or null);
           }
           {
             name = "libc";
@@ -428,12 +428,12 @@ rec {
           {
             name = "libc";
             packageId = "libc";
-            target = { target, features }: (("aarch64" == target."arch") && ("linux" == target."os"));
+            target = { target, features }: (("aarch64" == target."arch" or null) && ("linux" == target."os" or null));
           }
           {
             name = "libc";
             packageId = "libc";
-            target = { target, features }: (("aarch64" == target."arch") && ("apple" == target."vendor"));
+            target = { target, features }: (("aarch64" == target."arch" or null) && ("apple" == target."vendor" or null));
           }
         ];
 
@@ -1310,7 +1310,7 @@ rec {
           {
             name = "fuchsia-cprng";
             packageId = "fuchsia-cprng";
-            target = { target, features }: ("fuchsia" == target."os");
+            target = { target, features }: ("fuchsia" == target."os" or null);
           }
           {
             name = "libc";
@@ -1322,12 +1322,12 @@ rec {
             name = "rand_core";
             packageId = "rand_core 0.3.1";
             usesDefaultFeatures = false;
-            target = { target, features }: ("sgx" == target."env");
+            target = { target, features }: ("sgx" == target."env" or null);
           }
           {
             name = "rdrand";
             packageId = "rdrand";
-            target = { target, features }: ("sgx" == target."env");
+            target = { target, features }: ("sgx" == target."env" or null);
           }
           {
             name = "winapi";
@@ -1721,7 +1721,7 @@ rec {
           {
             name = "cpufeatures";
             packageId = "cpufeatures";
-            target = { target, features }: (("aarch64" == target."arch") || ("x86_64" == target."arch") || ("x86" == target."arch"));
+            target = { target, features }: (("aarch64" == target."arch" or null) || ("x86_64" == target."arch" or null) || ("x86" == target."arch" or null));
           }
           {
             name = "digest";

--- a/crate2nix/src/render.rs
+++ b/crate2nix/src/render.rs
@@ -224,7 +224,7 @@ fn cfg_to_nix_expr(cfg: &CfgExpr) -> String {
                 } else if key == "target_family" {
                     format!("(builtins.elem {} target.{})", escaped_value, target(key))
                 } else {
-                    format!("({} == target.{})", escaped_value, target(key))
+                    format!("({} == target.{} or null)", escaped_value, target(key))
                 });
             }
             CfgExpr::Not(expr) => {
@@ -292,19 +292,19 @@ fn test_render_cfg_to_nix_expr() {
         &cfg_to_nix_expr(&kv("target_family", "unix"))
     );
     assert_eq!(
-        "(\"linux\" == target.\"os\")",
+        "(\"linux\" == target.\"os\" or null)",
         &cfg_to_nix_expr(&kv("target_os", "linux"))
     );
     assert_eq!(
-        "(!(\"linux\" == target.\"os\"))",
+        "(!(\"linux\" == target.\"os\" or null))",
         &cfg_to_nix_expr(&CfgExpr::Not(Box::new(kv("target_os", "linux"))))
     );
     assert_eq!(
-        "((target.\"unix\" or false) || (\"linux\" == target.\"os\"))",
+        "((target.\"unix\" or false) || (\"linux\" == target.\"os\" or null))",
         &cfg_to_nix_expr(&CfgExpr::Any(vec![name("unix"), kv("target_os", "linux")]))
     );
     assert_eq!(
-        "((target.\"unix\" or false) && (\"linux\" == target.\"os\"))",
+        "((target.\"unix\" or false) && (\"linux\" == target.\"os\" or null))",
         &cfg_to_nix_expr(&CfgExpr::All(vec![name("unix"), kv("target_os", "linux")]))
     );
     assert_eq!("true", &cfg_to_nix_expr(&CfgExpr::All(vec![])));

--- a/sample_projects/bin/Cargo.toml
+++ b/sample_projects/bin/Cargo.toml
@@ -8,3 +8,6 @@ edition = "2018"
 
 [target.'cfg(never_happens)'.dependencies]
 cfg-if = "1"
+
+[target.'cfg(doesnt_exist = "should pass")'.dependencies]
+cfg-if = "1"

--- a/sample_projects/bin_with_git_submodule_dep/Cargo.nix
+++ b/sample_projects/bin_with_git_submodule_dep/Cargo.nix
@@ -119,7 +119,7 @@ rec {
           {
             name = "winapi";
             packageId = "winapi";
-            target = { target, features }: ("windows" == target."os");
+            target = { target, features }: ("windows" == target."os" or null);
             features = [ "errhandlingapi" "consoleapi" "processenv" ];
           }
         ];
@@ -648,7 +648,7 @@ rec {
           {
             name = "wasi";
             packageId = "wasi";
-            target = { target, features }: ("wasi" == target."os");
+            target = { target, features }: ("wasi" == target."os" or null);
           }
         ];
         features = {
@@ -908,7 +908,7 @@ rec {
           {
             name = "hermit-abi";
             packageId = "hermit-abi";
-            target = { target, features }: ((("x86_64" == target."arch") || ("aarch64" == target."arch")) && ("hermit" == target."os"));
+            target = { target, features }: ((("x86_64" == target."arch" or null) || ("aarch64" == target."arch" or null)) && ("hermit" == target."os" or null));
           }
           {
             name = "libc";

--- a/sample_projects/codegen/Cargo.nix
+++ b/sample_projects/codegen/Cargo.nix
@@ -97,7 +97,7 @@ rec {
           {
             name = "winapi";
             packageId = "winapi";
-            target = { target, features }: ("windows" == target."os");
+            target = { target, features }: ("windows" == target."os" or null);
             features = [ "errhandlingapi" "consoleapi" "processenv" ];
           }
         ];


### PR DESCRIPTION
I ran into an error where the evaluation of whether a dependency is used was accessing non-existent target values, and failing:

```
       at /nix/store/41ra1jaz5pn2rddqbf7j5csj0vn5whl8-services-crate2nix/crate/Cargo-generated.nix:4950:58:

         4949|             packageId = "curve25519-dalek-derive";
         4950|             target = { target, features }: ((!("fiat" == target."curve25519_dalek_backend")) && (!("serial" == target."curve25519_dalek_backend")) && ("x86_64" == target."arch"));
             |                                                          ^
         4951|           }

```

[curve25519-dalek uses `--cfg` (target) values to switch between different cryptographic backends.](https://github.com/dalek-cryptography/curve25519-dalek/tree/e6675c67ceadecc3e22b561296490f4b7de9ff39/curve25519-dalek#manual-backend-override)

This kind of fallback is already present, but only for checking whether a value is defined, not for comparisons:

https://github.com/nix-community/crate2nix/blob/e5372757075fc93c7624131069fa5d22ed88c4fd/crate2nix/src/render.rs#L216

I chose null only as a value to which no string will compare positively, theoretically this could be any non-string value.

The alternative is probably to continue failing loudly, instead of covering up the lack of a cfg value.
If that is preferred, a way of setting them globally/per-crate should be documented (I didn't find it), but it might be tedious if many dependencies use a lot of these variables.