### PR TITLE
fix cross-compilation

### DIFF
--- a/crate2nix/Cargo.nix
+++ b/crate2nix/Cargo.nix
@@ -2651,10 +2651,12 @@ rec {
         passthru = (crate.passthru or { }) // {
           inherit test;
         };
-      } ''
-      echo tested by ${test}
-      ${lib.concatMapStringsSep "\n" (output: "ln -s ${crate.${output}} ${"$"}${output}") crate.outputs}
-    '';
+      }
+      (lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+        echo tested by ${test}
+      '' + ''
+        ${lib.concatMapStringsSep "\n" (output: "ln -s ${crate.${output}} ${"$"}${output}") crate.outputs}
+      '');
 
   /* A restricted overridable version of builtRustCratesWithFeatures. */
   buildRustCrateWithFeatures =

--- a/crate2nix/Cargo.nix
+++ b/crate2nix/Cargo.nix
@@ -2621,7 +2621,7 @@ rec {
           # recreate a file hierarchy as when running tests with cargo
 
           # the source for test data
-          ${pkgs.xorg.lndir}/bin/lndir ${crate.src}
+          ${pkgs.buildPackages.xorg.lndir}/bin/lndir ${crate.src}
 
           # build outputs
           testRoot=target/debug

--- a/crate2nix/templates/nix/crate2nix/default.nix
+++ b/crate2nix/templates/nix/crate2nix/default.nix
@@ -165,10 +165,12 @@ rec {
         passthru = (crate.passthru or { }) // {
           inherit test;
         };
-      } ''
-      echo tested by ${test}
-      ${lib.concatMapStringsSep "\n" (output: "ln -s ${crate.${output}} ${"$"}${output}") crate.outputs}
-    '';
+      }
+      (lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+        echo tested by ${test}
+      '' + ''
+        ${lib.concatMapStringsSep "\n" (output: "ln -s ${crate.${output}} ${"$"}${output}") crate.outputs}
+      '');
 
   /* A restricted overridable version of builtRustCratesWithFeatures. */
   buildRustCrateWithFeatures =

--- a/crate2nix/templates/nix/crate2nix/default.nix
+++ b/crate2nix/templates/nix/crate2nix/default.nix
@@ -135,7 +135,7 @@ rec {
           # recreate a file hierarchy as when running tests with cargo
 
           # the source for test data
-          ${pkgs.xorg.lndir}/bin/lndir ${crate.src}
+          ${pkgs.buildPackages.xorg.lndir}/bin/lndir ${crate.src}
 
           # build outputs
           testRoot=target/debug

--- a/sample_projects/bin_with_git_submodule_dep/Cargo.nix
+++ b/sample_projects/bin_with_git_submodule_dep/Cargo.nix
@@ -1483,7 +1483,7 @@ rec {
           # recreate a file hierarchy as when running tests with cargo
 
           # the source for test data
-          ${pkgs.xorg.lndir}/bin/lndir ${crate.src}
+          ${pkgs.buildPackages.xorg.lndir}/bin/lndir ${crate.src}
 
           # build outputs
           testRoot=target/debug

--- a/sample_projects/bin_with_git_submodule_dep/Cargo.nix
+++ b/sample_projects/bin_with_git_submodule_dep/Cargo.nix
@@ -1513,10 +1513,12 @@ rec {
         passthru = (crate.passthru or { }) // {
           inherit test;
         };
-      } ''
-      echo tested by ${test}
-      ${lib.concatMapStringsSep "\n" (output: "ln -s ${crate.${output}} ${"$"}${output}") crate.outputs}
-    '';
+      }
+      (lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+        echo tested by ${test}
+      '' + ''
+        ${lib.concatMapStringsSep "\n" (output: "ln -s ${crate.${output}} ${"$"}${output}") crate.outputs}
+      '');
 
   /* A restricted overridable version of builtRustCratesWithFeatures. */
   buildRustCrateWithFeatures =

--- a/sample_projects/codegen/Cargo.nix
+++ b/sample_projects/codegen/Cargo.nix
@@ -615,7 +615,7 @@ rec {
           # recreate a file hierarchy as when running tests with cargo
 
           # the source for test data
-          ${pkgs.xorg.lndir}/bin/lndir ${crate.src}
+          ${pkgs.buildPackages.xorg.lndir}/bin/lndir ${crate.src}
 
           # build outputs
           testRoot=target/debug

--- a/sample_projects/codegen/Cargo.nix
+++ b/sample_projects/codegen/Cargo.nix
@@ -645,10 +645,12 @@ rec {
         passthru = (crate.passthru or { }) // {
           inherit test;
         };
-      } ''
-      echo tested by ${test}
-      ${lib.concatMapStringsSep "\n" (output: "ln -s ${crate.${output}} ${"$"}${output}") crate.outputs}
-    '';
+      }
+      (lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+        echo tested by ${test}
+      '' + ''
+        ${lib.concatMapStringsSep "\n" (output: "ln -s ${crate.${output}} ${"$"}${output}") crate.outputs}
+      '');
 
   /* A restricted overridable version of builtRustCratesWithFeatures. */
   buildRustCrateWithFeatures =

--- a/sample_projects/sub_dir_crates/Cargo.nix
+++ b/sample_projects/sub_dir_crates/Cargo.nix
@@ -297,10 +297,12 @@ rec {
         passthru = (crate.passthru or { }) // {
           inherit test;
         };
-      } ''
-      echo tested by ${test}
-      ${lib.concatMapStringsSep "\n" (output: "ln -s ${crate.${output}} ${"$"}${output}") crate.outputs}
-    '';
+      }
+      (lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+        echo tested by ${test}
+      '' + ''
+        ${lib.concatMapStringsSep "\n" (output: "ln -s ${crate.${output}} ${"$"}${output}") crate.outputs}
+      '');
 
   /* A restricted overridable version of builtRustCratesWithFeatures. */
   buildRustCrateWithFeatures =

--- a/sample_projects/sub_dir_crates/Cargo.nix
+++ b/sample_projects/sub_dir_crates/Cargo.nix
@@ -267,7 +267,7 @@ rec {
           # recreate a file hierarchy as when running tests with cargo
 
           # the source for test data
-          ${pkgs.xorg.lndir}/bin/lndir ${crate.src}
+          ${pkgs.buildPackages.xorg.lndir}/bin/lndir ${crate.src}
 
           # build outputs
           testRoot=target/debug


### PR DESCRIPTION
This contains fixes for cross-compilation, initially proposed by @amjoseph-nixpkgs as two patches to `Cargo.nix` (https://cl.tvl.fyi/9888, https://cl.tvl.fyi/9889)

These patches, together with a nixpkgs past https://github.com/NixOS/nixpkgs/pull/220429 (b10994c38c61038970a19fa60bfbec21a61755cc) allowed cross-compiling `tvix-cli` for aarch64-linux.