### PR TITLE
Fix systems

### DIFF
--- a/templates/flake-binary/flake.nix
+++ b/templates/flake-binary/flake.nix
@@ -34,7 +34,7 @@
       systems = [
         "x86_64-linux"
         "aarch64-linux"
-        "x86_64-linux"
+        "x86_64-darwin"
         "aarch64-darwin"
       ];
 


### PR DESCRIPTION
I noticed the `systems` variable contained `"x86_64-linux"` twice, and I believe this might be an error.