### PR TITLE
fix(template): run tests in `/build/source` instead `/build`

### DIFF
--- a/crate2nix/Cargo.nix
+++ b/crate2nix/Cargo.nix
@@ -2889,6 +2889,16 @@ rec {
           # recreate a file hierarchy as when running tests with cargo
 
           # the source for test data
+          # It's necessary to locate the source in $NIX_BUILD_TOP/source/
+          # instead of $NIX_BUILD_TOP/
+          # because we compiled those test binaries in the former and not the latter.
+          # So all paths will expect source tree to be there and not in the build top directly.
+          # For example: $NIX_BUILD_TOP := /build in general, if you ask yourself.
+          # TODO(raitobezarius): I believe there could be more edge cases if `crate.sourceRoot`
+          # do exist but it's very hard to reason about them, so let's wait until the first bug report.
+          mkdir -p source/
+          cd source/
+
           ${pkgs.buildPackages.xorg.lndir}/bin/lndir ${crate.src}
 
           # build outputs

--- a/crate2nix/templates/nix/crate2nix/default.nix
+++ b/crate2nix/templates/nix/crate2nix/default.nix
@@ -135,6 +135,16 @@ rec {
           # recreate a file hierarchy as when running tests with cargo
 
           # the source for test data
+          # It's necessary to locate the source in $NIX_BUILD_TOP/source/
+          # instead of $NIX_BUILD_TOP/
+          # because we compiled those test binaries in the former and not the latter.
+          # So all paths will expect source tree to be there and not in the build top directly.
+          # For example: $NIX_BUILD_TOP := /build in general, if you ask yourself.
+          # TODO(raitobezarius): I believe there could be more edge cases if `crate.sourceRoot`
+          # do exist but it's very hard to reason about them, so let's wait until the first bug report.
+          mkdir -p source/
+          cd source/
+
           ${pkgs.buildPackages.xorg.lndir}/bin/lndir ${crate.src}
 
           # build outputs

--- a/sample_projects/bin_with_git_submodule_dep/Cargo.nix
+++ b/sample_projects/bin_with_git_submodule_dep/Cargo.nix
@@ -1483,6 +1483,16 @@ rec {
           # recreate a file hierarchy as when running tests with cargo
 
           # the source for test data
+          # It's necessary to locate the source in $NIX_BUILD_TOP/source/
+          # instead of $NIX_BUILD_TOP/
+          # because we compiled those test binaries in the former and not the latter.
+          # So all paths will expect source tree to be there and not in the build top directly.
+          # For example: $NIX_BUILD_TOP := /build in general, if you ask yourself.
+          # TODO(raitobezarius): I believe there could be more edge cases if `crate.sourceRoot`
+          # do exist but it's very hard to reason about them, so let's wait until the first bug report.
+          mkdir -p source/
+          cd source/
+
           ${pkgs.buildPackages.xorg.lndir}/bin/lndir ${crate.src}
 
           # build outputs

--- a/sample_projects/codegen/Cargo.nix
+++ b/sample_projects/codegen/Cargo.nix
@@ -658,6 +658,16 @@ rec {
           # recreate a file hierarchy as when running tests with cargo
 
           # the source for test data
+          # It's necessary to locate the source in $NIX_BUILD_TOP/source/
+          # instead of $NIX_BUILD_TOP/
+          # because we compiled those test binaries in the former and not the latter.
+          # So all paths will expect source tree to be there and not in the build top directly.
+          # For example: $NIX_BUILD_TOP := /build in general, if you ask yourself.
+          # TODO(raitobezarius): I believe there could be more edge cases if `crate.sourceRoot`
+          # do exist but it's very hard to reason about them, so let's wait until the first bug report.
+          mkdir -p source/
+          cd source/
+
           ${pkgs.buildPackages.xorg.lndir}/bin/lndir ${crate.src}
 
           # build outputs

--- a/sample_projects/sub_dir_crates/Cargo.nix
+++ b/sample_projects/sub_dir_crates/Cargo.nix
@@ -267,6 +267,16 @@ rec {
           # recreate a file hierarchy as when running tests with cargo
 
           # the source for test data
+          # It's necessary to locate the source in $NIX_BUILD_TOP/source/
+          # instead of $NIX_BUILD_TOP/
+          # because we compiled those test binaries in the former and not the latter.
+          # So all paths will expect source tree to be there and not in the build top directly.
+          # For example: $NIX_BUILD_TOP := /build in general, if you ask yourself.
+          # TODO(raitobezarius): I believe there could be more edge cases if `crate.sourceRoot`
+          # do exist but it's very hard to reason about them, so let's wait until the first bug report.
+          mkdir -p source/
+          cd source/
+
           ${pkgs.buildPackages.xorg.lndir}/bin/lndir ${crate.src}
 
           # build outputs


### PR DESCRIPTION
Previously, the source tree was located inline in `/build` during tests, this was a mistake because the crates more than often are built in `/build/source` as per the `sourceRoot` system.

This can cause issues with test binaries hardcoding `/build/source/...` as their choice for doing things, causing them to be confused in the test phase which is relocated without rewriting the paths inside test binaries.

We fix that by relocating ourselves in the right hierarchy.

This is a "simple" fix in the sense that more edge cases could exist but they are hard to reason about because they would be crates using custom `sourceRoot`, i.e. having `crate.sourceRoot` set and then it becomes a bit hard to reproduce the hierarchy, you need to analyze whether the path is absolute or relative,

If it's relative, you can just reuse it and reproduce that specific hierarchy. If it's absolute, you need to cut the "absolute" meaningless part, e.g. `$NIX_BUILD_TOP/` and proceed like it's a relative path IMHO.

Fixes #327.