### PR TITLE
Stop fabricating PackageId and look it up instead

### DIFF
--- a/crate2nix/src/metadata.rs
+++ b/crate2nix/src/metadata.rs
@@ -22,7 +22,7 @@ use serde::Serialize;
 #[derive(Debug)]
 pub struct MergedMetadata {
     workspace_members: Vec<PackageId>,
-    packages: Vec<Package>,
+    pub(crate) packages: Vec<Package>,
     root: Option<PackageId>,
     nodes: Vec<Node>,
 }


### PR DESCRIPTION
- lock.rs: get rid of confusing Metadata type alias
- IndexedMetadata::new_from_merged doesn't consume MergedMetadata
- Lookup PackageId in resolved metadata

Fixes #340 