### PR TITLE
Fix: Use mkDerivation with src instead of runCommand for test derivation

### DIFF
--- a/crate2nix/Cargo.nix
+++ b/crate2nix/Cargo.nix
@@ -3248,52 +3248,41 @@ rec {
               testPostRun
             ]);
         in
-        pkgs.runCommand "run-tests-${testCrate.name}"
-          {
-            inherit testCrateFlags;
-            buildInputs = testInputs;
-          } ''
-          set -e
+        pkgs.stdenvNoCC.mkDerivation {
+          name = "run-tests-${testCrate.name}";
 
-          export RUST_BACKTRACE=1
+          inherit (crate) src;
 
-          # recreate a file hierarchy as when running tests with cargo
+          inherit testCrateFlags;
 
-          # the source for test data
-          # It's necessary to locate the source in $NIX_BUILD_TOP/source/
-          # instead of $NIX_BUILD_TOP/
-          # because we compiled those test binaries in the former and not the latter.
-          # So all paths will expect source tree to be there and not in the build top directly.
-          # For example: $NIX_BUILD_TOP := /build in general, if you ask yourself.
-          # NOTE: There could be edge cases if `crate.sourceRoot` does exist but
-          # it's very hard to reason about them.
-          # Open a bug if you run into this!
-          mkdir -p source/
-          cd source/
+          buildInputs = testInputs;
 
-          ${pkgs.buildPackages.xorg.lndir}/bin/lndir ${crate.src}
+          buildPhase = ''
+            set -e
+            export RUST_BACKTRACE=1
 
-          # build outputs
-          testRoot=target/debug
-          mkdir -p $testRoot
+            # build outputs
+            testRoot=target/debug
+            mkdir -p $testRoot
 
-          # executables of the crate
-          # we copy to prevent std::env::current_exe() to resolve to a store location
-          for i in ${crate}/bin/*; do
-            cp "$i" "$testRoot"
-          done
-          chmod +w -R .
+            # executables of the crate
+            # we copy to prevent std::env::current_exe() to resolve to a store location
+            for i in ${crate}/bin/*; do
+              cp "$i" "$testRoot"
+            done
+            chmod +w -R .
 
-          # test harness executables are suffixed with a hash, like cargo does
-          # this allows to prevent name collision with the main
-          # executables of the crate
-          hash=$(basename $out)
-          for file in ${drv}/tests/*; do
-            f=$testRoot/$(basename $file)-$hash
-            cp $file $f
-            ${testCommand}
-          done
-        '';
+            # test harness executables are suffixed with a hash, like cargo does
+            # this allows to prevent name collision with the main
+            # executables of the crate
+            hash=$(basename $out)
+            for file in ${drv}/tests/*; do
+              f=$testRoot/$(basename $file)-$hash
+              cp $file $f
+              ${testCommand}
+            done
+          '';
+        };
     in
     pkgs.runCommand "${crate.name}-linked"
       {

--- a/crate2nix/templates/nix/crate2nix/default.nix
+++ b/crate2nix/templates/nix/crate2nix/default.nix
@@ -120,52 +120,41 @@ rec {
               testPostRun
             ]);
         in
-        pkgs.runCommand "run-tests-${testCrate.name}"
-          {
-            inherit testCrateFlags;
-            buildInputs = testInputs;
-          } ''
-          set -e
+        pkgs.stdenvNoCC.mkDerivation {
+          name = "run-tests-${testCrate.name}";
 
-          export RUST_BACKTRACE=1
+          inherit (crate) src;
 
-          # recreate a file hierarchy as when running tests with cargo
+          inherit testCrateFlags;
 
-          # the source for test data
-          # It's necessary to locate the source in $NIX_BUILD_TOP/source/
-          # instead of $NIX_BUILD_TOP/
-          # because we compiled those test binaries in the former and not the latter.
-          # So all paths will expect source tree to be there and not in the build top directly.
-          # For example: $NIX_BUILD_TOP := /build in general, if you ask yourself.
-          # NOTE: There could be edge cases if `crate.sourceRoot` does exist but
-          # it's very hard to reason about them.
-          # Open a bug if you run into this!
-          mkdir -p source/
-          cd source/
+          buildInputs = testInputs;
 
-          ${pkgs.buildPackages.xorg.lndir}/bin/lndir ${crate.src}
+          buildPhase = ''
+            set -e
+            export RUST_BACKTRACE=1
 
-          # build outputs
-          testRoot=target/debug
-          mkdir -p $testRoot
+            # build outputs
+            testRoot=target/debug
+            mkdir -p $testRoot
 
-          # executables of the crate
-          # we copy to prevent std::env::current_exe() to resolve to a store location
-          for i in ${crate}/bin/*; do
-            cp "$i" "$testRoot"
-          done
-          chmod +w -R .
+            # executables of the crate
+            # we copy to prevent std::env::current_exe() to resolve to a store location
+            for i in ${crate}/bin/*; do
+              cp "$i" "$testRoot"
+            done
+            chmod +w -R .
 
-          # test harness executables are suffixed with a hash, like cargo does
-          # this allows to prevent name collision with the main
-          # executables of the crate
-          hash=$(basename $out)
-          for file in ${drv}/tests/*; do
-            f=$testRoot/$(basename $file)-$hash
-            cp $file $f
-            ${testCommand}
-          done
-        '';
+            # test harness executables are suffixed with a hash, like cargo does
+            # this allows to prevent name collision with the main
+            # executables of the crate
+            hash=$(basename $out)
+            for file in ${drv}/tests/*; do
+              f=$testRoot/$(basename $file)-$hash
+              cp $file $f
+              ${testCommand}
+            done
+          '';
+        };
     in
     pkgs.runCommand "${crate.name}-linked"
       {

--- a/sample_projects/bin_with_git_submodule_dep/Cargo.nix
+++ b/sample_projects/bin_with_git_submodule_dep/Cargo.nix
@@ -1466,52 +1466,41 @@ rec {
               testPostRun
             ]);
         in
-        pkgs.runCommand "run-tests-${testCrate.name}"
-          {
-            inherit testCrateFlags;
-            buildInputs = testInputs;
-          } ''
-          set -e
+        pkgs.stdenvNoCC.mkDerivation {
+          name = "run-tests-${testCrate.name}";
 
-          export RUST_BACKTRACE=1
+          inherit (crate) src;
 
-          # recreate a file hierarchy as when running tests with cargo
+          inherit testCrateFlags;
 
-          # the source for test data
-          # It's necessary to locate the source in $NIX_BUILD_TOP/source/
-          # instead of $NIX_BUILD_TOP/
-          # because we compiled those test binaries in the former and not the latter.
-          # So all paths will expect source tree to be there and not in the build top directly.
-          # For example: $NIX_BUILD_TOP := /build in general, if you ask yourself.
-          # NOTE: There could be edge cases if `crate.sourceRoot` does exist but
-          # it's very hard to reason about them.
-          # Open a bug if you run into this!
-          mkdir -p source/
-          cd source/
+          buildInputs = testInputs;
 
-          ${pkgs.buildPackages.xorg.lndir}/bin/lndir ${crate.src}
+          buildPhase = ''
+            set -e
+            export RUST_BACKTRACE=1
 
-          # build outputs
-          testRoot=target/debug
-          mkdir -p $testRoot
+            # build outputs
+            testRoot=target/debug
+            mkdir -p $testRoot
 
-          # executables of the crate
-          # we copy to prevent std::env::current_exe() to resolve to a store location
-          for i in ${crate}/bin/*; do
-            cp "$i" "$testRoot"
-          done
-          chmod +w -R .
+            # executables of the crate
+            # we copy to prevent std::env::current_exe() to resolve to a store location
+            for i in ${crate}/bin/*; do
+              cp "$i" "$testRoot"
+            done
+            chmod +w -R .
 
-          # test harness executables are suffixed with a hash, like cargo does
-          # this allows to prevent name collision with the main
-          # executables of the crate
-          hash=$(basename $out)
-          for file in ${drv}/tests/*; do
-            f=$testRoot/$(basename $file)-$hash
-            cp $file $f
-            ${testCommand}
-          done
-        '';
+            # test harness executables are suffixed with a hash, like cargo does
+            # this allows to prevent name collision with the main
+            # executables of the crate
+            hash=$(basename $out)
+            for file in ${drv}/tests/*; do
+              f=$testRoot/$(basename $file)-$hash
+              cp $file $f
+              ${testCommand}
+            done
+          '';
+        };
     in
     pkgs.runCommand "${crate.name}-linked"
       {

--- a/sample_projects/codegen/Cargo.nix
+++ b/sample_projects/codegen/Cargo.nix
@@ -641,52 +641,41 @@ rec {
               testPostRun
             ]);
         in
-        pkgs.runCommand "run-tests-${testCrate.name}"
-          {
-            inherit testCrateFlags;
-            buildInputs = testInputs;
-          } ''
-          set -e
+        pkgs.stdenvNoCC.mkDerivation {
+          name = "run-tests-${testCrate.name}";
 
-          export RUST_BACKTRACE=1
+          inherit (crate) src;
 
-          # recreate a file hierarchy as when running tests with cargo
+          inherit testCrateFlags;
 
-          # the source for test data
-          # It's necessary to locate the source in $NIX_BUILD_TOP/source/
-          # instead of $NIX_BUILD_TOP/
-          # because we compiled those test binaries in the former and not the latter.
-          # So all paths will expect source tree to be there and not in the build top directly.
-          # For example: $NIX_BUILD_TOP := /build in general, if you ask yourself.
-          # NOTE: There could be edge cases if `crate.sourceRoot` does exist but
-          # it's very hard to reason about them.
-          # Open a bug if you run into this!
-          mkdir -p source/
-          cd source/
+          buildInputs = testInputs;
 
-          ${pkgs.buildPackages.xorg.lndir}/bin/lndir ${crate.src}
+          buildPhase = ''
+            set -e
+            export RUST_BACKTRACE=1
 
-          # build outputs
-          testRoot=target/debug
-          mkdir -p $testRoot
+            # build outputs
+            testRoot=target/debug
+            mkdir -p $testRoot
 
-          # executables of the crate
-          # we copy to prevent std::env::current_exe() to resolve to a store location
-          for i in ${crate}/bin/*; do
-            cp "$i" "$testRoot"
-          done
-          chmod +w -R .
+            # executables of the crate
+            # we copy to prevent std::env::current_exe() to resolve to a store location
+            for i in ${crate}/bin/*; do
+              cp "$i" "$testRoot"
+            done
+            chmod +w -R .
 
-          # test harness executables are suffixed with a hash, like cargo does
-          # this allows to prevent name collision with the main
-          # executables of the crate
-          hash=$(basename $out)
-          for file in ${drv}/tests/*; do
-            f=$testRoot/$(basename $file)-$hash
-            cp $file $f
-            ${testCommand}
-          done
-        '';
+            # test harness executables are suffixed with a hash, like cargo does
+            # this allows to prevent name collision with the main
+            # executables of the crate
+            hash=$(basename $out)
+            for file in ${drv}/tests/*; do
+              f=$testRoot/$(basename $file)-$hash
+              cp $file $f
+              ${testCommand}
+            done
+          '';
+        };
     in
     pkgs.runCommand "${crate.name}-linked"
       {

--- a/sample_projects/sub_dir_crates/Cargo.nix
+++ b/sample_projects/sub_dir_crates/Cargo.nix
@@ -250,52 +250,41 @@ rec {
               testPostRun
             ]);
         in
-        pkgs.runCommand "run-tests-${testCrate.name}"
-          {
-            inherit testCrateFlags;
-            buildInputs = testInputs;
-          } ''
-          set -e
+        pkgs.stdenvNoCC.mkDerivation {
+          name = "run-tests-${testCrate.name}";
 
-          export RUST_BACKTRACE=1
+          inherit (crate) src;
 
-          # recreate a file hierarchy as when running tests with cargo
+          inherit testCrateFlags;
 
-          # the source for test data
-          # It's necessary to locate the source in $NIX_BUILD_TOP/source/
-          # instead of $NIX_BUILD_TOP/
-          # because we compiled those test binaries in the former and not the latter.
-          # So all paths will expect source tree to be there and not in the build top directly.
-          # For example: $NIX_BUILD_TOP := /build in general, if you ask yourself.
-          # NOTE: There could be edge cases if `crate.sourceRoot` does exist but
-          # it's very hard to reason about them.
-          # Open a bug if you run into this!
-          mkdir -p source/
-          cd source/
+          buildInputs = testInputs;
 
-          ${pkgs.buildPackages.xorg.lndir}/bin/lndir ${crate.src}
+          buildPhase = ''
+            set -e
+            export RUST_BACKTRACE=1
 
-          # build outputs
-          testRoot=target/debug
-          mkdir -p $testRoot
+            # build outputs
+            testRoot=target/debug
+            mkdir -p $testRoot
 
-          # executables of the crate
-          # we copy to prevent std::env::current_exe() to resolve to a store location
-          for i in ${crate}/bin/*; do
-            cp "$i" "$testRoot"
-          done
-          chmod +w -R .
+            # executables of the crate
+            # we copy to prevent std::env::current_exe() to resolve to a store location
+            for i in ${crate}/bin/*; do
+              cp "$i" "$testRoot"
+            done
+            chmod +w -R .
 
-          # test harness executables are suffixed with a hash, like cargo does
-          # this allows to prevent name collision with the main
-          # executables of the crate
-          hash=$(basename $out)
-          for file in ${drv}/tests/*; do
-            f=$testRoot/$(basename $file)-$hash
-            cp $file $f
-            ${testCommand}
-          done
-        '';
+            # test harness executables are suffixed with a hash, like cargo does
+            # this allows to prevent name collision with the main
+            # executables of the crate
+            hash=$(basename $out)
+            for file in ${drv}/tests/*; do
+              f=$testRoot/$(basename $file)-$hash
+              cp $file $f
+              ${testCommand}
+            done
+          '';
+        };
     in
     pkgs.runCommand "${crate.name}-linked"
       {


### PR DESCRIPTION
The problem with using runCommand and recreating the src directory with
lndir is that it changes the file types of individual files, they will
now be a symlink instead of a regular file. If you have a crate that tests
that a file is of regular type then it will fail inside the crate2nix derivation.
