### PR TITLE
test stdenv derivation: set dontInstall

### DIFF
--- a/crate2nix/templates/nix/crate2nix/default.nix
+++ b/crate2nix/templates/nix/crate2nix/default.nix
@@ -154,6 +154,8 @@ rec {
               ${testCommand}
             done
           '';
+
+           dontInstall = true;
         };
     in
     pkgs.runCommand "${crate.name}-linked"


### PR DESCRIPTION
In a "normal" Rust crate, the installPhase will do nothing, since stdenv setup.sh will look for a file called Makefile, and then bail out when it doesn't find it.

However, in a Rust crate that has a file called Makefile, the installPhase will run, and will do broken things. In particular, I see consistent failures of the form

```
...
++ [[ -z '' ]]
++ [[ -e Makefile ]]
++ foundMakefile=1
++ '[' -n /nix/store/1avx3g6yx60xgbfvrzalysz572cr8ghg-run-tests-rust_secp256k1-zkp-0.11.0 ']'
++ mkdir -p /nix/store/1avx3g6yx60xgbfvrzalysz572cr8ghg-run-tests-rust_secp256k1-zkp-0.11.0
mkdir: cannot create directory '/nix/store/1avx3g6yx60xgbfvrzalysz572cr8ghg-run-tests-rust_secp256k1-zkp-0.11.0': File exists
+ exitHandler
+ exitCode=1
...
```

This derivation was introduced in #357; previously we simply used runCommand which has no notion of "phases". When we switched to stdenv we moved the runCommand functionality into buildPhase and didn't consider that any of the other default phases might do bad stuff.