### PR TITLE
Fix small error in 80_using_a_rust_overlay.md

### DIFF
--- a/docs/src/content/docs/00_guides/80_using_a_rust_overlay.md
+++ b/docs/src/content/docs/00_guides/80_using_a_rust_overlay.md
@@ -52,7 +52,7 @@ In a flake with flake-parts:
               cargo = pkgs.rust-bin.stable.latest.default;
             };
             
-          generatedCargoNix = inputs.crate2nix.tools.${system}.appliedCargoNix {
+          generatedCargoNix = inputs.crate2nix.tools.${system}.generatedCargoNix {
             name = "rustnix";
             src = ./.;
           };


### PR DESCRIPTION
I'm pretty sure this needs to be `generatedCargoNix` instead of `appliedCargoNix`. I'm no expert using this project but I think I spent some time debugging this before, and today again, where I fixed my problem by changing this.