### PR TITLE
do not prefetch git dependencies

### DIFF
--- a/crate2nix/src/config.rs
+++ b/crate2nix/src/config.rs
@@ -10,6 +10,8 @@ use std::{
     path::Path,
 };
 
+use crate::CommitHash;
+
 impl Config {
     /// Read config from path.
     pub fn read_from_or_default(path: &Path) -> Result<Config, Error> {
@@ -112,7 +114,7 @@ pub enum Source {
         /// E.g. https://github.com/kolloch/crate2nix.git
         url: url::Url,
         /// The revision hash.
-        rev: String,
+        rev: CommitHash,
         /// The sha256 of the fetched result.
         sha256: String,
     },

--- a/crate2nix/src/lib.rs
+++ b/crate2nix/src/lib.rs
@@ -42,6 +42,8 @@ pub mod sources;
 pub mod test;
 pub mod util;
 
+pub use util::CommitHash;
+
 /// The resolved build info and the input for rendering the build.nix.tera template.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct BuildInfo {

--- a/crate2nix/src/main.rs
+++ b/crate2nix/src/main.rs
@@ -1,3 +1,4 @@
+use crate2nix::CommitHash;
 use std::path::{Path, PathBuf};
 use structopt::clap::ArgGroup;
 use structopt::StructOpt;
@@ -273,8 +274,8 @@ pub enum SourceAddingCommands {
         /// E.g. https://github.com/kolloch/crate2nix.git
         url: url::Url,
 
-        #[structopt(long = "rev", parse(from_str), help = "The git revision hash.")]
-        rev: String,
+        #[structopt(long = "rev", parse(try_from_str = CommitHash::try_from), help = "The git revision hash.")]
+        rev: CommitHash,
     },
 
     #[structopt(

--- a/crate2nix/src/prefetch.rs
+++ b/crate2nix/src/prefetch.rs
@@ -314,6 +314,7 @@ impl PrefetchableSource for RegistrySource {
 
 impl PrefetchableSource for GitSource {
     fn needs_prefetch(&self) -> bool {
+        // self.rev is sufficient for reproducible fetching, and that field is mandatory
         false
     }
 

--- a/crate2nix/src/prefetch.rs
+++ b/crate2nix/src/prefetch.rs
@@ -334,7 +334,7 @@ impl PrefetchableSource for GitSource {
             self.url.as_str(),
             "--fetch-submodules",
             "--rev",
-            &self.rev,
+            self.rev.as_ref(),
         ];
 
         // TODO: --branch-name isn't documented in nix-prefetch-git --help

--- a/crate2nix/src/prefetch.rs
+++ b/crate2nix/src/prefetch.rs
@@ -314,7 +314,7 @@ impl PrefetchableSource for RegistrySource {
 
 impl PrefetchableSource for GitSource {
     fn needs_prefetch(&self) -> bool {
-        self.sha256.is_none()
+        false
     }
 
     fn prefetch(&self) -> Result<String, Error> {

--- a/crate2nix/src/resolve.rs
+++ b/crate2nix/src/resolve.rs
@@ -20,6 +20,7 @@ use std::path::{Path, PathBuf};
 use crate::metadata::IndexedMetadata;
 #[cfg(test)]
 use crate::test;
+use crate::CommitHash;
 use crate::GenerateConfig;
 use itertools::Itertools;
 use std::{collections::btree_map::BTreeMap, fmt::Display};
@@ -421,7 +422,7 @@ pub struct RegistrySource {
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Hash)]
 pub struct GitSource {
     pub url: Url,
-    pub rev: String,
+    pub rev: CommitHash,
     pub r#ref: Option<String>,
     pub sha256: Option<String>,
 }
@@ -494,13 +495,40 @@ impl ResolvedSource {
         }
         let mut url = url::Url::parse(&source_string[GIT_SOURCE_PREFIX.len()..])?;
         let mut query_pairs = url.query_pairs();
+
+        // Locked git sources have optional ?branch or ?tag or ?rev query arguments. It is
+        // important to capture these in case the given commit hash is not reachable from the
+        // repo's default HEAD. OTOH if no form of ref is given that is an implication by cargo
+        // that the default HEAD should be fetched.
         let branch = query_pairs
             .find(|(k, _)| k == "branch")
             .map(|(_, v)| v.to_string());
-        let rev = if let Some((_, rev)) = query_pairs.find(|(k, _)| k == "rev") {
-            rev.to_string()
-        } else if let Some(rev) = url.fragment() {
-            rev.to_string()
+        let tag = query_pairs
+            .find(|(k, _)| k == "tag")
+            .map(|(_, v)| format!("refs/tags/{v}"));
+        let ref_via_rev = query_pairs
+            .find(|(k, _)| k == "rev")
+            // Rev is usually a commit hash, but in some cases it can be a ref. Use as a ref only
+            // if it is not a valid commit hash.
+            .filter(|(_, v)| CommitHash::parse(v).is_none())
+            .map(|(_, v)| v.to_string());
+        let r#ref = branch.or(tag).or(ref_via_rev);
+
+        // In locked sources the git commit hash is given as a URL fragment. It sometimes also
+        // given in a ?rev query argument. But in other cases a ?rev argument might not be a commit
+        // hash: the [cargo reference docs][] give an example of a rev argument of `"refs/pull/493/head"`.
+        //
+        // [cargo reference docs]: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html
+        //
+        // That example applies to a Cargo.toml manifest - but such rev arguments do seem to be
+        // preserved in the lock file.
+        let rev = if let Some(rev) = url.fragment().and_then(CommitHash::parse) {
+            rev
+        } else if let Some(rev) = query_pairs
+            .find(|(k, _)| k == "rev")
+            .and_then(|(_, rev)| CommitHash::parse(&rev))
+        {
+            rev
         } else {
             return ResolvedSource::fallback_to_local_directory(
                 config,
@@ -509,12 +537,13 @@ impl ResolvedSource {
                 "No git revision found.",
             );
         };
+
         url.set_query(None);
         url.set_fragment(None);
         Ok(ResolvedSource::Git(GitSource {
             url,
             rev,
-            r#ref: branch,
+            r#ref,
             sha256: None,
         }))
     }

--- a/crate2nix/src/sources.rs
+++ b/crate2nix/src/sources.rs
@@ -4,6 +4,7 @@ use crate::{
     config,
     prefetch::PrefetchableSource,
     resolve::{CratesIoSource, GitSource, RegistrySource},
+    CommitHash,
 };
 use anyhow::{bail, format_err, Context, Error};
 use semver::Version;
@@ -59,7 +60,7 @@ pub fn registry_source(
 }
 
 /// Returns the completed Source::Git definition by prefetching the hash.
-pub fn git_io_source(url: Url, rev: String) -> Result<config::Source, Error> {
+pub fn git_io_source(url: Url, rev: CommitHash) -> Result<config::Source, Error> {
     let prefetchable = GitSource {
         url: url.clone(),
         rev: rev.clone(),

--- a/crate2nix/src/util.rs
+++ b/crate2nix/src/util.rs
@@ -1,6 +1,10 @@
 //! Homeless code. Usually abstract and algorithmic.
 
+use core::{convert::AsRef, fmt::Display};
 use std::collections::BTreeSet;
+
+use anyhow::anyhow;
+use serde::{Deserialize, Serialize};
 
 /// Return all occurrences of each item after the first.
 /// ```
@@ -13,4 +17,50 @@ use std::collections::BTreeSet;
 pub fn find_duplicates<'a, T: Ord>(source: impl Iterator<Item = &'a T>) -> Vec<&'a T> {
     let mut seen = BTreeSet::new();
     source.filter(|v| !seen.insert(*v)).collect()
+}
+
+/// Newtype for a string that has been verified to be a git commit hash, and has been normalized.
+#[derive(Clone, Debug, Hash, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(try_from = "String")]
+pub struct CommitHash(String);
+
+impl CommitHash {
+    /// If the string contains 40 hexadecimal characters returns a normalized string by trimming
+    /// leading and trailing whitespace, and converting alphabetical characters to lower case.
+    pub fn parse(input: &str) -> Option<Self> {
+        let normalized = input.trim().to_lowercase();
+        if normalized.len() == 40 && normalized.chars().all(|c| c.is_ascii_hexdigit()) {
+            Some(CommitHash(normalized))
+        } else {
+            None
+        }
+    }
+}
+
+impl AsRef<str> for CommitHash {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl TryFrom<String> for CommitHash {
+    type Error = anyhow::Error;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        <Self as TryFrom<&str>>::try_from(&value)
+    }
+}
+
+impl TryFrom<&str> for CommitHash {
+    type Error = anyhow::Error;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        CommitHash::parse(value).ok_or_else(|| anyhow!("value {value} is not a git commit hash"))
+    }
+}
+
+impl Display for CommitHash {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", self.0)
+    }
 }

--- a/crate2nix/templates/Cargo.nix.tera
+++ b/crate2nix/templates/Cargo.nix.tera
@@ -159,9 +159,9 @@ rec {
         src = builtins.fetchGit {
           url = {{crate.source.Git.url}};
           rev = {{crate.source.Git.rev}};
-          {% if crate.source.Git.ref %}
+          {%- if crate.source.Git.ref %}
           ref = {{ crate.source.Git.ref }};
-          {%- endif -%}
+          {%- endif %}
           submodules = true;
         };
         {%- else %}

--- a/crate2nix/templates/Cargo.nix.tera
+++ b/crate2nix/templates/Cargo.nix.tera
@@ -159,11 +159,12 @@ rec {
         src = builtins.fetchGit {
           url = {{crate.source.Git.url}};
           rev = {{crate.source.Git.rev}};
-          {%- if crate.source.Git.ref %}
+          {% if crate.source.Git.ref %}
           ref = {{ crate.source.Git.ref }};
           {%- else -%}
           allRefs = true;
           {%- endif %}
+          submodules = true;
         };
         {%- else %}
         src = builtins.throw ''ERROR: Could not resolve source: {{crate.source | json_encode() | safe}}'';

--- a/crate2nix/templates/Cargo.nix.tera
+++ b/crate2nix/templates/Cargo.nix.tera
@@ -156,11 +156,13 @@ rec {
         src = lib.cleanSourceWith { filter = sourceFilter;  src = {{crate.source.LocalDirectory.path | safe}}; };
         {%- elif crate.source.Git %}
         workspace_member = null;
-        src = pkgs.fetchgit {
+        src = builtins.fetchGit {
           url = {{crate.source.Git.url}};
           rev = {{crate.source.Git.rev}};
-          {%- if crate.source.Git.sha256 %}
-          sha256 = {{ crate.source.Git.sha256 }};
+          {%- if crate.source.Git.ref %}
+          ref = {{ crate.source.Git.ref }};
+          {%- else -%}
+          allRefs = true;
           {%- endif %}
         };
         {%- else %}

--- a/crate2nix/templates/Cargo.nix.tera
+++ b/crate2nix/templates/Cargo.nix.tera
@@ -161,9 +161,7 @@ rec {
           rev = {{crate.source.Git.rev}};
           {% if crate.source.Git.ref %}
           ref = {{ crate.source.Git.ref }};
-          {%- else -%}
-          allRefs = true;
-          {%- endif %}
+          {%- endif -%}
           submodules = true;
         };
         {%- else %}

--- a/sample_projects/bin_with_git_branch_dep/crate-hashes.json
+++ b/sample_projects/bin_with_git_branch_dep/crate-hashes.json
@@ -1,3 +1,0 @@
-{
-  "nix-base32 0.1.2-alpha.0 (git+https://github.com/kolloch/nix-base32?branch=branch-for-test#42f5544e51187f0c7535d453fcffb4b524c99eb2)": "011f945b48xkilkqbvbsxazspz5z23ka0s90ms4jiqjbhiwll1nw"
-}

--- a/sample_projects/bin_with_git_submodule_dep/Cargo.nix
+++ b/sample_projects/bin_with_git_submodule_dep/Cargo.nix
@@ -485,10 +485,11 @@ rec {
         edition = "2018";
         links = "rocksdb";
         workspace_member = null;
-        src = pkgs.fetchgit {
+        src = builtins.fetchGit {
           url = "https://github.com/rust-rocksdb/rust-rocksdb";
           rev = "66f04df013b6e6bd42b5a8c353406e09a7c7da2a";
-          sha256 = "1rchvjrjamdaznx26gy4bmjj10rrf00mgc1wvkc489r9z1nh4h1h";
+
+          submodules = true;
         };
         authors = [
           "Karl Hobley <karlhobley10@gmail.com>"
@@ -837,10 +838,11 @@ rec {
         version = "0.21.0";
         edition = "2018";
         workspace_member = null;
-        src = pkgs.fetchgit {
+        src = builtins.fetchGit {
           url = "https://github.com/rust-rocksdb/rust-rocksdb";
           rev = "66f04df013b6e6bd42b5a8c353406e09a7c7da2a";
-          sha256 = "1rchvjrjamdaznx26gy4bmjj10rrf00mgc1wvkc489r9z1nh4h1h";
+
+          submodules = true;
         };
         authors = [
           "Tyler Neely <t@jujit.su>"

--- a/sample_projects/bin_with_git_submodule_dep/Cargo.nix
+++ b/sample_projects/bin_with_git_submodule_dep/Cargo.nix
@@ -488,7 +488,6 @@ rec {
         src = builtins.fetchGit {
           url = "https://github.com/rust-rocksdb/rust-rocksdb";
           rev = "66f04df013b6e6bd42b5a8c353406e09a7c7da2a";
-
           submodules = true;
         };
         authors = [
@@ -841,7 +840,6 @@ rec {
         src = builtins.fetchGit {
           url = "https://github.com/rust-rocksdb/rust-rocksdb";
           rev = "66f04df013b6e6bd42b5a8c353406e09a7c7da2a";
-
           submodules = true;
         };
         authors = [

--- a/sample_projects/bin_with_git_submodule_dep/crate-hashes.json
+++ b/sample_projects/bin_with_git_submodule_dep/crate-hashes.json
@@ -1,4 +1,0 @@
-{
-  "librocksdb-sys 0.15.0+8.9.1 (git+https://github.com/rust-rocksdb/rust-rocksdb#66f04df013b6e6bd42b5a8c353406e09a7c7da2a)": "1rchvjrjamdaznx26gy4bmjj10rrf00mgc1wvkc489r9z1nh4h1h",
-  "rocksdb 0.21.0 (git+https://github.com/rust-rocksdb/rust-rocksdb#66f04df013b6e6bd42b5a8c353406e09a7c7da2a)": "1rchvjrjamdaznx26gy4bmjj10rrf00mgc1wvkc489r9z1nh4h1h"
-}

--- a/sample_projects/bin_with_lib_git_dep/crate-hashes.json
+++ b/sample_projects/bin_with_lib_git_dep/crate-hashes.json
@@ -1,3 +1,0 @@
-{
-  "nix-base32 0.1.2-alpha.0 (git+https://github.com/kolloch/nix-base32?rev=42f5544e51187f0c7535d453fcffb4b524c99eb2#42f5544e51187f0c7535d453fcffb4b524c99eb2)": "011f945b48xkilkqbvbsxazspz5z23ka0s90ms4jiqjbhiwll1nw"
-}

--- a/sample_projects/codegen/Cargo.nix
+++ b/sample_projects/codegen/Cargo.nix
@@ -252,7 +252,6 @@ rec {
         src = builtins.fetchGit {
           url = "https://github.com/diwic/dbus-rs.git";
           rev = "618262f5e3217cdd173d46d705bbac26c5141e21";
-
           submodules = true;
         };
         authors = [
@@ -291,7 +290,6 @@ rec {
         src = builtins.fetchGit {
           url = "https://github.com/diwic/dbus-rs.git";
           rev = "618262f5e3217cdd173d46d705bbac26c5141e21";
-
           submodules = true;
         };
         authors = [
@@ -367,7 +365,6 @@ rec {
         src = builtins.fetchGit {
           url = "https://github.com/diwic/dbus-rs.git";
           rev = "618262f5e3217cdd173d46d705bbac26c5141e21";
-
           submodules = true;
         };
         authors = [

--- a/sample_projects/codegen/Cargo.nix
+++ b/sample_projects/codegen/Cargo.nix
@@ -249,10 +249,11 @@ rec {
         version = "0.9.7";
         edition = "2018";
         workspace_member = null;
-        src = pkgs.fetchgit {
+        src = builtins.fetchGit {
           url = "https://github.com/diwic/dbus-rs.git";
           rev = "618262f5e3217cdd173d46d705bbac26c5141e21";
-          sha256 = "0gvhz2knd1k799l7ssh4rdm5qw0vhazzr3bxpmlgq7fhy6hjazrs";
+
+          submodules = true;
         };
         authors = [
           "David Henningsson <diwic@ubuntu.com>"
@@ -287,10 +288,11 @@ rec {
         edition = "2018";
         crateBin = [];
         workspace_member = null;
-        src = pkgs.fetchgit {
+        src = builtins.fetchGit {
           url = "https://github.com/diwic/dbus-rs.git";
           rev = "618262f5e3217cdd173d46d705bbac26c5141e21";
-          sha256 = "0gvhz2knd1k799l7ssh4rdm5qw0vhazzr3bxpmlgq7fhy6hjazrs";
+
+          submodules = true;
         };
         authors = [
           "David Henningsson <diwic@ubuntu.com>"
@@ -362,10 +364,11 @@ rec {
         edition = "2015";
         links = "dbus";
         workspace_member = null;
-        src = pkgs.fetchgit {
+        src = builtins.fetchGit {
           url = "https://github.com/diwic/dbus-rs.git";
           rev = "618262f5e3217cdd173d46d705bbac26c5141e21";
-          sha256 = "0gvhz2knd1k799l7ssh4rdm5qw0vhazzr3bxpmlgq7fhy6hjazrs";
+
+          submodules = true;
         };
         authors = [
           "David Henningsson <diwic@ubuntu.com>"

--- a/sample_projects/codegen/crate-hashes.json
+++ b/sample_projects/codegen/crate-hashes.json
@@ -1,5 +1,0 @@
-{
-  "dbus 0.9.7 (git+https://github.com/diwic/dbus-rs.git#618262f5e3217cdd173d46d705bbac26c5141e21)": "0gvhz2knd1k799l7ssh4rdm5qw0vhazzr3bxpmlgq7fhy6hjazrs",
-  "dbus-codegen 0.10.0 (git+https://github.com/diwic/dbus-rs.git#618262f5e3217cdd173d46d705bbac26c5141e21)": "0gvhz2knd1k799l7ssh4rdm5qw0vhazzr3bxpmlgq7fhy6hjazrs",
-  "libdbus-sys 0.2.5 (git+https://github.com/diwic/dbus-rs.git#618262f5e3217cdd173d46d705bbac26c5141e21)": "0gvhz2knd1k799l7ssh4rdm5qw0vhazzr3bxpmlgq7fhy6hjazrs"
-}

--- a/sample_projects/sub_dir_crates/Cargo.nix
+++ b/sample_projects/sub_dir_crates/Cargo.nix
@@ -93,10 +93,11 @@ rec {
         version = "0.1.0";
         edition = "2018";
         workspace_member = null;
-        src = pkgs.fetchgit {
+        src = builtins.fetchGit {
           url = "https://github.com/kolloch/with_sub_crates.git";
           rev = "f8ad2b98ff0eb5fea4962f55e3ced5b0b5afe973";
-          sha256 = "0nlw7rg28p6bya040cbipq4jdcdp4h3q9shdjygfk2xkva9bjl8w";
+
+          submodules = true;
         };
         authors = [
           "Peter Kolloch <info@eigenvalue.net>"
@@ -108,10 +109,11 @@ rec {
         version = "0.1.0";
         edition = "2018";
         workspace_member = null;
-        src = pkgs.fetchgit {
+        src = builtins.fetchGit {
           url = "https://github.com/kolloch/with_sub_crates.git";
           rev = "f8ad2b98ff0eb5fea4962f55e3ced5b0b5afe973";
-          sha256 = "0nlw7rg28p6bya040cbipq4jdcdp4h3q9shdjygfk2xkva9bjl8w";
+
+          submodules = true;
         };
         authors = [
           "Peter Kolloch <info@eigenvalue.net>"

--- a/sample_projects/sub_dir_crates/Cargo.nix
+++ b/sample_projects/sub_dir_crates/Cargo.nix
@@ -96,7 +96,6 @@ rec {
         src = builtins.fetchGit {
           url = "https://github.com/kolloch/with_sub_crates.git";
           rev = "f8ad2b98ff0eb5fea4962f55e3ced5b0b5afe973";
-
           submodules = true;
         };
         authors = [
@@ -112,7 +111,6 @@ rec {
         src = builtins.fetchGit {
           url = "https://github.com/kolloch/with_sub_crates.git";
           rev = "f8ad2b98ff0eb5fea4962f55e3ced5b0b5afe973";
-
           submodules = true;
         };
         authors = [

--- a/sample_projects/sub_dir_crates/crate-hashes.json
+++ b/sample_projects/sub_dir_crates/crate-hashes.json
@@ -1,4 +1,0 @@
-{
-  "lib1 0.1.0 (git+https://github.com/kolloch/with_sub_crates.git?rev=f8ad2b98ff0eb5fea4962f55e3ced5b0b5afe973#f8ad2b98ff0eb5fea4962f55e3ced5b0b5afe973)": "0nlw7rg28p6bya040cbipq4jdcdp4h3q9shdjygfk2xkva9bjl8w",
-  "lib2 0.1.0 (git+https://github.com/kolloch/with_sub_crates.git?rev=f8ad2b98ff0eb5fea4962f55e3ced5b0b5afe973#f8ad2b98ff0eb5fea4962f55e3ced5b0b5afe973)": "0nlw7rg28p6bya040cbipq4jdcdp4h3q9shdjygfk2xkva9bjl8w"
-}

--- a/tools.nix
+++ b/tools.nix
@@ -397,18 +397,20 @@ rec {
                 else if builtins.hasAttr "branch" parsed then parsed.branch
                 else if builtins.hasAttr "ref" parsed then parsed.ref
                 else null;
+              rev =
+                if isNull parsed.rev
+                then parsed.urlFragment
+                else parsed.rev;
               src-spec = {
-                  inherit (parsed) url;
-                  allRefs = isNull ref;
-                  name = srcname;
-                  rev =
-                    if isNull parsed.urlFragment
-                    then parsed.rev
-                    else parsed.urlFragment;
-                } // lib.optionalAttrs (!(isNull ref)) {
+                inherit (parsed) url;
+                allRefs = isNull ref;
+                name = srcname;
+              } // lib.optionalAttrs (!(isNull ref)) {
                 inherit ref;
+              } // lib.optionalAttrs (!(isNull rev)) {
+                inherit rev;
               };
-              src = builtins.trace src-spec.rev (builtins.trace src-spec (builtins.fetchGit src-spec));
+              src = builtins.fetchGit src-spec;
 
               rootCargo = builtins.fromTOML (builtins.readFile "${src}/Cargo.toml");
               isWorkspace = rootCargo ? "workspace";

--- a/tools.nix
+++ b/tools.nix
@@ -233,11 +233,6 @@ rec {
       in
       if builtins.isString str && isValidHash then normalized else null;
 
-    # Returns input unchanged if it is a non-empty string. Otherwise returns
-    # null.
-    parseCommitRef = str:
-      if builtins.isString str && builtins.match "^\s*$" str != null then str else null;
-
     gatherLockFiles = crateDir:
       let
         fromCrateDir =

--- a/tools.nix
+++ b/tools.nix
@@ -393,17 +393,15 @@ rec {
               parsed = parseGitSource source;
               srcname = "${name}-${version}";
               ref =
-                if builtins.hasAttr "tag" parsed then "refs/tags/${parsed.tag}"
-                else if builtins.hasAttr "branch" parsed then parsed.branch
-                else if builtins.hasAttr "ref" parsed then parsed.ref
+                if parsed ? tag then "refs/tags/${parsed.tag}"
+                else if parsed ? branch then parsed.branch
+                else if parsed ? ref then parsed.ref
                 else null;
               rev =
-                if builtins.hasAttr "rev" parsed
-                then parsed.rev
-                else builtins.trace parsed parsed.urlFragment;
+                if parsed ? rev then parsed.rev
+                else parsed.urlFragment;
               src-spec = {
                 inherit (parsed) url;
-                allRefs = isNull ref;
                 name = srcname;
                 submodules = true;
               } // lib.optionalAttrs (!(isNull ref)) {

--- a/tools.nix
+++ b/tools.nix
@@ -398,13 +398,14 @@ rec {
                 else if builtins.hasAttr "ref" parsed then parsed.ref
                 else null;
               rev =
-                if isNull parsed.rev
-                then parsed.urlFragment
-                else parsed.rev;
+                if builtins.hasAttr "rev" parsed
+                then parsed.rev
+                else builtins.trace parsed parsed.urlFragment;
               src-spec = {
                 inherit (parsed) url;
                 allRefs = isNull ref;
                 name = srcname;
+                submodules = true;
               } // lib.optionalAttrs (!(isNull ref)) {
                 inherit ref;
               } // lib.optionalAttrs (!(isNull rev)) {


### PR DESCRIPTION
Git prefetching is made unnecessary by switching from `pkgs.fetchgit` to `builtins.fetchGit`. In addition to simplifying handling git deps this change is a necessary prerequisite to handling git dependencies inside cargo workspaces when running crate2nix in IFD mode.

Since this change requires modifying git-fetching code in multiple places I took some steps to make fetching as consistent as possible in each place. Part of that was introduce steps to parse git hashes to verify that those inputs are indeed valid hashes. On the Rust side that is done with the type `CommitHash`. On the Nix side there is `parseCommitHash`.