### PR TITLE
docs(guide): :memo: fix `rust-overlay` guide

### DIFF
--- a/docs/src/content/docs/00_guides/80_using_a_rust_overlay.md
+++ b/docs/src/content/docs/00_guides/80_using_a_rust_overlay.md
@@ -52,7 +52,7 @@ In a flake with flake-parts:
               cargo = pkgs.rust-bin.stable.latest.default;
             };
             
-          generatedCargoNix = inputs.crate2nix.tools.${system}.appliedCargoNix {
+          generatedCargoNix = inputs.crate2nix.tools.${system}.generatedCargoNix {
             name = "rustnix";
             src = ./.;
           };


### PR DESCRIPTION
The guide of using `rust-overlay` was committed at #360. However, it has a typo and thus cannot build the derivation successfully, which confused me for a while.

After searching for examples, I found in #359, author used `generatedCargoNix` instead of `appliedCargoNix`, then I switched to it, make my crate successful to build.