### PR TITLE
generatedCargoNix: allow selected toolchain

### DIFF
--- a/tools.nix
+++ b/tools.nix
@@ -32,6 +32,7 @@ rec {
     , additionalCargoNixArgs ? [ ]
     , additionalCrateHashes ? internal.parseOptHashesFile
         (src + "/crate-hashes.json")
+    , cargo ? pkgs.cargo
     }:
     let
       crateDir = dirOf (src + "/${cargoToml}");
@@ -44,7 +45,7 @@ rec {
     stdenv.mkDerivation {
       name = "${name}-crate2nix";
 
-      buildInputs = [ pkgs.cargo pkgs.jq crate2nix ];
+      buildInputs = [ cargo crate2nix pkgs.jq ];
       preferLocalBuild = true;
 
       inherit src;


### PR DESCRIPTION
Rust projects can use newer or custom toolchains that are not available in nixpkgs, even more so now that Rust Edition 2024 is upon us.

Attempting to generate `Cargo.nix` via IFD for a project with edition 2024 currently fails, no matter which version of `cargo`  would be found on the `$PATH` first.

<details>
<summary>Logs from build failure</summary>
Running phase: unpackPhase
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking source archive /nix/store/hx77ikpfvx0r0l6w7q20gcwh0qass5j7-rust
source root is rust
Running phase: buildPhase
@nix { "action": "setPhase", "phase": "buildPhase" }
++ crate2nix generate -f ./Cargo.toml -o Cargo-generated.nix -h /nix/store/wzj8q30d3kalhpsrhray6vj5y8xazl89-workspace-crate2nix/crate-hashes.json
Error: while retrieving metadata about ./Cargo.toml: `cargo metadata` exited with an error: warning: `/nix/store/wzj8q30d3kalhpsrhray6vj5y8xazl89-workspace-crate2nix/cargo/config` is deprecated in favor of `config.toml`
note: if you need to support cargo 1.38 or earlier, you can symlink `config` to `config.toml`
error: failed to load manifest for workspace member `/private/tmp/nix-build-workspace-crate2nix.drv-0/rust/nix-cst`
referenced by workspace at `/private/tmp/nix-build-workspace-crate2nix.drv-0/rust/Cargo.toml`

Caused by:
  failed to parse manifest at `/private/tmp/nix-build-workspace-crate2nix.drv-0/rust/nix-cst/Cargo.toml`

Caused by:
  feature `edition2024` is required

  The package requires the Cargo feature called `edition2024`, but that feature is not stabilized in this version of Cargo (1.82.0 (8f40fc59f 2024-08-21)).
  Consider adding `cargo-features = ["edition2024"]` to the top of Cargo.toml (above the [package] table) to tell Cargo you are opting in to use this unstable feature.
  See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#edition-2024 for more information about the status of this feature.

crate2nix failed.
== cargo/config (BEGIN)
    [source.crates-io]
    replace-with = "vendored-sources"
    
    
    [source.vendored-sources]
    directory = "/nix/store/4h8s39mxr5c0im1snn153wam1hym45c4-deps"

== cargo/config (END)

== crate-hashes.json (BEGIN)
    {}
== crate-hashes.json (END)

== ls -la (BEGIN)
total 16
drwxr-xr-x 7 _nixbld1 nixbld 224 Jan  1  1970 .
drwx------ 4 _nixbld1 nixbld 128 Feb 21 23:13 ..
-rw-r--r-- 1 _nixbld1 nixbld 437 Jan  1  1970 .gitignore
-rw-r--r-- 1 _nixbld1 nixbld 151 Jan  1  1970 Cargo.lock
-rw-r--r-- 1 _nixbld1 nixbld  49 Jan  1  1970 Cargo.toml
-rw-r--r-- 1 _nixbld1 nixbld 325 Jan  1  1970 default.nix
drwxr-xr-x 4 _nixbld1 nixbld 128 Jan  1  1970 nix-cst
== ls -la (END)
</details>

The reason for this is that `crate2nix` uses `pkgs.cargo` by default, and `pkgs` is already bound to what `flake.nix` is locked to, which yields a Cargo 1.82 currently, which does not support edition 2024.

This CAN be overridden as [per this guide](https://nix-community.github.io/crate2nix/00_guides/42_custom_toolchains/), which requires setting `cargo` in an overlay prior thereto.

While functional, this approach is quite blunt, requiring a flake-wide override just to satisfy a tool that is not used to build the actual project.
My proposed solution is to simply pass a `cargo` argument to `generatedCargoNix` function. If it is omitted, then we fallback to `pkgs.cargo`, thereby retaining existing behavior.