### PR TITLE
Copy over symbols (dSYM/) on MacOS

### DIFF
--- a/crate2nix/templates/nix/crate2nix/default.nix
+++ b/crate2nix/templates/nix/crate2nix/default.nix
@@ -187,7 +187,7 @@ rec {
               # executables of the crate
               # we copy to prevent std::env::current_exe() to resolve to a store location
               for i in ${crate}/bin/*; do
-                cp "$i" "$testRoot"
+                cp -r "$i" "$testRoot"
               done
               chmod +w -R .
 


### PR DESCRIPTION
Debug symbols are generated as dSYM bundles (directories) on MacOS. This ensures that these are copied and that `cp` won't fail if said symbols are enabled.